### PR TITLE
Covers the case when replaced text = new text + original text 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,11 @@ with the returned host:port combination.
 var arr = require("async-regex-replace");
 
 arr.replace(/regex/g, "String with regex to replace", function(match, callback) { 
-  var replacement_value = match[0].split('').reverse().join('');
-  var err = null;
-  callback(err, replacement_value); 
+  setTimeout(function() {
+    var replacement_value = match[0].split('').reverse().join('');
+    var err = null;
+    callback(err, replacement_value); 
+  }, 1000);
 }, function(err, final_result) {
   if(err) { console.log("Error - " + err); }
   else { 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-var dns = require("dns");
-
 module.exports = {
 	replace : replace,
 	Replacer : Replacer
@@ -20,6 +18,7 @@ module.exports = {
  *
  */
 function replace(regex, str, replacer, done) {
+	regex.lastIndex = 0;
 	var match = regex.exec(str);
 	if(match==null) { // No matches, we are done.
 		done(null, str);
@@ -33,12 +32,15 @@ function replace(regex, str, replacer, done) {
 			var matchIndex = match.index;
 			var matchLength = match[0].length;
 			// Splice the replacement back into the string
-			var new_str = str.substring(0,matchIndex) + result + str.substring(matchIndex + matchLength);
+			var accum = str.substring(0,matchIndex) + result;
+			var rest = str.substring(matchIndex + matchLength);
 			if(regex.global) { // Keep replacing
-				replace(regex, new_str, replacer, done);
+				replace(regex, rest, replacer, function(err, remaining) {
+						done(err, accum + remaining);
+					});
 			}
 			else {
-				done(null, new_str);
+				done(null, accum + rest);
 			}
 		});
 	}

--- a/test/index.js
+++ b/test/index.js
@@ -10,9 +10,12 @@ var replacers = {
 			cb("Unexpected match - " + match[0]);
 		}
 	},
-        reverse : function(match, cb) {
+	reverse : function(match, cb) {
 		cb(null, match[0].split('').reverse().join(''));
-        }
+	},
+	recurring : function(match, cb) {
+		cb(null, '[' + match[0] + '](' + match[0] + ')');
+	}
 }
 
 describe("async-regex-replace", function() {
@@ -67,6 +70,16 @@ describe("async-regex-replace", function() {
 			done);
 		});
 
+		it("single match, recurring replace", function(done) {
+			run_test({
+				regex : /match/g,
+				string : "This is the string to match.",
+				expected : "This is the string to [match](match).",
+				replacer : replacers.recurring
+			},
+			done);
+		});
+
 		it("multiple matches, simple replace, global flag missing", function(done) {
 			run_test({
 				regex : /match/,
@@ -83,6 +96,16 @@ describe("async-regex-replace", function() {
 				string : "The first should match and the second should match.",
 				expected : "The first should replace and the second should replace.",
 				replacer : replacers.simple
+			},
+			done);
+		});
+
+		it("multiple matches, recurring replace", function(done) {
+			run_test({
+				regex : /match/g,
+				string : "The first should match and the second should match.",
+				expected : "The first should [match](match) and the second should [match](match).",
+				replacer : replacers.recurring
 			},
 			done);
 		});
@@ -107,5 +130,15 @@ describe("async-regex-replace", function() {
 			done);
 
 		});
+
+		it("reusable replacer recurring", function(done) {
+			run_test( {
+				replacer: async_regex_replace.Replacer(/match/, replacers.recurring),
+				string : "This is the string to match.",
+				expected : "This is the string to [match](match).",
+			},
+			done);
+		});
+
 	});
 });


### PR DESCRIPTION
Reusing the `regex` to keep track of the offset. Good idea. Works great on most cases.
But doesn't work for this case.

**Input:** `<@JackSparrow>`
**Output:** `(Jack Sparrow)<@JackSparrow>`

```
var arr = require("./index.js");

var re = /<@([A-Z][^A-Z>]+)([A-Z][^A-Z>]+)>/g;
var str = "Once upon a time <@JackSparrow> and <@JillValentine> went up the hill";

console.log(str); 

// Sync replace
var newStr = str.replace(re, function(m, p1, p2, o, s) { return '(' + p1 + ' ' + p2 + ')' + m; });
console.log(newStr);

// Async replace
arr.replace(re,
        str,
        function(match, callback) { 
            setTimeout(function() {
                var replacement_value = '(' + match[1] + ' ' + match[2] + ')' + match[0];
                console.log("Expanding " + match[0] + " to " + replacement_value);
                var err = null;
                callback(err, replacement_value); 
            }, 1000);
        },
        function(err, final_result) {
            if(err) {
                console.log("Error - " + err);
            }
            else { 
                // Outputs: "String with xeger to replace"
                console.log(final_result); 
            }
        }
);

```

This would stuck in a loop with the current implementation.
- Removed unnecessary `require("dns");`
- Updated README with a simple async callback

BTW, very useful utility. 👍
